### PR TITLE
Matching multiple assets in a single file

### DIFF
--- a/tasks/userev.js
+++ b/tasks/userev.js
@@ -62,18 +62,19 @@ module.exports = function (grunt) {
         }).forEach(function(filepath) {
           var content = grunt.file.read(filepath);
           var updated = false;
-          var replacement, lastLink, baseLink, hashLink;
+          var replacement, lastLink, baseLink, hashLink, index;
 
           for (var label in options.patterns) {
             var match,match_pos;
             var pattern = options.patterns[label];
-            var searchContent = content
+            var matches = content.match(pattern);
 
-            while ((match = pattern.exec(searchContent)) !== null) {
+            for (index in matches) {
+              var match = matches[index];
               if (match) {
                 grunt.log.debug('Matching ' + [filepath, pattern, JSON.stringify(match)].join(': '));
-                replacement = match[0];
-                lastLink = match[1] || match[0];
+                replacement = match;
+                lastLink = match;
                 baseLink = options.hash ? replaceFirstGroup(lastLink, options.hash, '') : lastLink;
                 for (var assetpath in versioned) {
                   if (endsWith(assetpath, baseLink)) {
@@ -86,7 +87,7 @@ module.exports = function (grunt) {
                       grunt.log.writeln('Linking ' + label + ': ' + lastLink +
                         (baseLink !== lastLink ? ' -> ' + baseLink : '') + ' -> ' + hashLink.green);
                       replacement = replacement.replace(lastLink, hashLink);
-                      content = content.replace(match[0], replacement);
+                      content = content.replace(match, replacement);
                       updated = true;
                     } else {
                       grunt.log.writeln('Already linked ' + label + ': ' +
@@ -98,8 +99,6 @@ module.exports = function (grunt) {
                       (baseLink !== lastLink ? ' -> ' + baseLink : '') + ' <> ' + assetpath);
                   }
                 }
-                match_pos = content.indexOf(replacement)
-                searchContent = content.slice(match_pos + match[0].length)
               } else {
                 grunt.log.debug('Not matching ' + filepath + ': ' + pattern);
               }

--- a/tasks/userev.js
+++ b/tasks/userev.js
@@ -86,7 +86,7 @@ module.exports = function (grunt) {
                       grunt.log.writeln('Linking ' + label + ': ' + lastLink +
                         (baseLink !== lastLink ? ' -> ' + baseLink : '') + ' -> ' + hashLink.green);
                       replacement = replacement.replace(lastLink, hashLink);
-                      content = content.replace(pattern, replacement);
+                      content = content.replace(match[0], replacement);
                       updated = true;
                     } else {
                       grunt.log.writeln('Already linked ' + label + ': ' +

--- a/tasks/userev.js
+++ b/tasks/userev.js
@@ -98,8 +98,8 @@ module.exports = function (grunt) {
                       (baseLink !== lastLink ? ' -> ' + baseLink : '') + ' <> ' + assetpath);
                   }
                 }
-                match_pos = content.indexOf(match[0])
-                searchContent = content.substr(match_pos + match[0].length)
+                match_pos = content.indexOf(replacement)
+                searchContent = content.slice(match_pos + match[0].length)
               } else {
                 grunt.log.debug('Not matching ' + filepath + ': ' + pattern);
               }


### PR DESCRIPTION
Match assets using str.match(regex) allowing the user to match multiple assets in a file if the global modifier is set on the regex.

Fixes: [#5](https://github.com/salsita/grunt-userev/issues/5)
